### PR TITLE
Use current_dir to fix the pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
+import os
 from setuptools import setup
 
+current_dir = os.path.dirname(os.path.abspath(__file__))
 
 if __name__ == '__main__':
   setup(
@@ -10,9 +12,9 @@ if __name__ == '__main__':
     author='Mark Steve Samson',
     author_email='hello@marksteve.com',
     description='Utilities for using Beanstalk with Flask',
-    long_description=open('README.rst').read(),
+    long_description=open(os.path.join(current_dir, 'README.rst')).read(),
     py_modules=['flask_beanstalk'],
     zip_safe=False,
     platforms='any',
-    install_requires=open('requirements.txt').readlines(),
+    install_requires=open(os.path.join(current_dir, 'requirements.txt')).readlines(),
   )


### PR DESCRIPTION
I try to install this library using pip and I always got this error:

```
$: pip install Flask-Beanstalk
Downloading/unpacking Flask-Beanstalk
  Downloading Flask-Beanstalk-0.0.1.tar.gz
  Running setup.py egg_info for package Flask-Beanstalk
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/vagrant/------------/venv/build/Flask-Beanstalk/setup.py", line 13, in <module>
        long_description=open('README.rst').read(),
    IOError: [Errno 2] No such file or directory: 'README.rst'
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/vagrant/-----------/venv/build/Flask-Beanstalk/setup.py", line 13, in <module>

    long_description=open('README.rst').read(),

IOError: [Errno 2] No such file or directory: 'README.rst'

----------------------------------------
Cleaning up...
```

Since it try to open the files into the same directory, I setup a `current_dir` variable and use it to open the files into the same folder using the full path of the file, so this will avoid this kind of error.
