### PR TITLE
Include the files required by setuptools in the build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include requirements.txt
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -1,22 +1,18 @@
-import os
 from setuptools import setup
-
-current_dir = os.path.dirname(os.path.abspath(__file__))
 
 if __name__ == '__main__':
   setup(
     name='Flask-Beanstalk',
-    version='0.0.2',
+    version='0.0.3',
     url='https://github.com/marksteve/flask-beanstalk',
     license='MIT',
     author='Mark Steve Samson',
     author_email='hello@marksteve.com',
     description='Utilities for using Beanstalk with Flask',
-    long_description=open(os.path.join(current_dir, 'README.rst')).read(),
+    long_description=open('README.rst').read(),
     py_modules=['flask_beanstalk'],
     zip_safe=False,
     platforms='any',
-    install_requires=open(
-      os.path.join(current_dir, 'requirements.txt'),
-    ).readlines(),
+    install_requires=open('requirements.txt').readlines(),
   )
+


### PR DESCRIPTION
Even with the modification that I made, I still have the same problem in my CI server. I dig a little about it and I discover that the simple way to do it is include those files into the `MANIFEST.in`, so they will be copied for the build folder and work with the old code (that is much more simple than my own version). So I rollback your version and include the files into the MANIFEST.in.

This work fine in my local computer and into the CI server.

o/
